### PR TITLE
Fix parsing Export-Package entry

### DIFF
--- a/bundle-viewer/pom.xml
+++ b/bundle-viewer/pom.xml
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,6 +36,7 @@
     <build>
         <finalName>${project.artifactId}</finalName>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/bundle-viewer/src/org/jvnet/hk2/ExportedPackage.java
+++ b/bundle-viewer/src/org/jvnet/hk2/ExportedPackage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,6 +49,7 @@ public class ExportedPackage extends Named implements Comparable<ExportedPackage
             sc.read(USES);
             uses = Collections.unmodifiableSet(
                 new TreeSet<String>(Arrays.asList(sc.readUntil('\"').split(","))));
+            sc.readUntil(';');
         } else
             uses = Collections.emptySet();
         if(sc.at(VERSION)) {

--- a/bundle-viewer/test/org/jvnet/hk2/LexerTest.java
+++ b/bundle-viewer/test/org/jvnet/hk2/LexerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.jvnet.hk2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class LexerTest {
+    private static String KNOWN_EXPORTS_ENTRY = "jakarta.ejb.spi;uses:=\"jakarta.ejb,jakarta.ejb.embeddable\";version=\"4.0.0\",jakarta.ejb;uses:=\"jakarta.transaction\";version=\"4.0.0\",jakarta.ejb.embeddable;uses:=\"jakarta.ejb.spi,jakarta.ejb,javax.naming\";version=\"4.0.0\"";
+
+    public void testFinding3ExportedPackages() {
+        Lexer lexer = new Lexer(KNOWN_EXPORTS_ENTRY);
+
+        List<ExportedPackage> packages = new ArrayList<ExportedPackage>();
+        while (!lexer.isEmpty()) {
+            packages.add(new ExportedPackage(lexer));
+        }
+
+        assert packages.size() == 3;
+    }
+
+    public void test1stExportedPackage() {
+        testFoundExportedPackage(KNOWN_EXPORTS_ENTRY, 0, "jakarta.ejb.spi",
+                Arrays.asList("jakarta.ejb", "jakarta.ejb.embeddable"), "4.0.0");
+
+    }
+
+    public void test2ndExportedPackage() {
+        testFoundExportedPackage(KNOWN_EXPORTS_ENTRY, 1, "jakarta.ejb",
+                Arrays.asList("jakarta.transaction"), "4.0.0");
+    }
+
+    public void test3rdExportedPackage() {
+        testFoundExportedPackage(KNOWN_EXPORTS_ENTRY, 2, "jakarta.ejb.embeddable",
+                Arrays.asList("jakarta.ejb.spi", "jakarta.ejb", "javax.naming"), "4.0.0");
+    }
+
+    private void testFoundExportedPackage(String manifestEntry, int packageIndex, String expectedName,
+                                          Collection<String> expectedUses, String expectedVersion) {
+        Lexer lexer = new Lexer(manifestEntry);
+
+        List<ExportedPackage> packages = new ArrayList<ExportedPackage>();
+        while (!lexer.isEmpty()) {
+            packages.add(new ExportedPackage(lexer));
+        }
+
+        ExportedPackage testedPackage = packages.get(packageIndex);
+
+        assert testedPackage.name.equals(expectedName);
+        assert testedPackage.uses.containsAll(expectedUses);
+        assert testedPackage.version.equals(expectedVersion);
+    }
+}
+


### PR DESCRIPTION
Fixes #20, giving:
```
$ java -jar bundle-viewer/target/bundle-viewer.jar ~/.m2/repository/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar
Bundle-Name:         Jakarta Enterprise Beans
Bundle-Version:      3.2.6
Bundle-SymbolicName: jakarta.ejb-api
Export-Packages:
  javax.ejb             3.2.6
  javax.ejb.embeddable  3.2.6
  javax.ejb.spi         3.2.6
  javax.xml.rpc.handler 1.1.2
Import-Packages:
  javax.ejb             3.2.6
  javax.ejb.embeddable  3.2.6
  javax.ejb.spi         3.2.6
  javax.naming         
  javax.transaction     [1.3,2.0)
  javax.xml.namespace  
  javax.xml.rpc.handler 1.1.2
Private-Packages:
Require-Bundles:
```