### PR TITLE
Migrate away from c.s..internal package

### DIFF
--- a/dependency-verifier/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/BCELClassFileLoader1.java
+++ b/dependency-verifier/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/BCELClassFileLoader1.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Logger;
 
-import com.sun.org.apache.bcel.internal.util.ClassPath;
+import org.apache.bcel.util.ClassPath;
 
 /**
  * Yet another factory for {@link BCELClassFile}. This is not a public class, as


### PR DESCRIPTION
`c.s.o.a.b.internal.util.ClassPath` is no longer available since https://bugs.openjdk.java.net/browse/JDK-8132256, and will be removed in JDK8u342 as well (https://bugs.openjdk.java.net/browse/JDK-8283529).