### PR TITLE
Retire JMX Experiment from the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <module>bundle-viewer</module>
         <module>dependency-verifier</module>
         <module>dependency-visualizer</module>
-        <module>experiments/jmx</module>
     </modules>
 
     <build>


### PR DESCRIPTION
I propose to exclude JMX experiment from the build.
It has not been modified in last ~15 years, if I'm not mistaken.
It uses classes from `com.sun` internal packages, that are not exported by their module.
This would unblock
- #45

I'd even go for removal, as for experiment I suppose it is done. This could be PRed separately.