### PR TITLE
Specify upper version bounds for imported OSGi-resource-locator packages

### DIFF
--- a/osgi-resource-locator/osgi.bundle
+++ b/osgi-resource-locator/osgi.bundle
@@ -18,4 +18,4 @@ Bundle-Activator: org.glassfish.hk2.osgiresourcelocator.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Version: ${project.osgi.version}
 Export-Package: org.glassfish.hk2.osgiresourcelocator;uses:="org.osgi.framework";version="${project.version}"
-Import-Package: org.glassfish.hk2.osgiresourcelocator; version="${project.version}", *
+Import-Package: org.glassfish.hk2.osgiresourcelocator; version="${range;[===,+)}", *


### PR DESCRIPTION
When multiple versions of the OSGi resource locator bundle are in the classpath, it may happen that the imported packages are resolved against a newer version of the bundle, even though they should be resolved against the bundle itself.